### PR TITLE
test: cover word exclusion matching

### DIFF
--- a/server/app/src/usecase/message_processor.rs
+++ b/server/app/src/usecase/message_processor.rs
@@ -98,3 +98,233 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        notification::StampNotification,
+        traq_message::{TraqMessage, TraqMessageUuid},
+        user::{NewUser, User, UserId},
+        word::{NewWord, Word, WordId, WordUuid, WordValue},
+    };
+    use anyhow::anyhow;
+    use std::{future::Future, sync::Mutex};
+    use uuid::Uuid;
+
+    struct FakeWord {
+        target_user_id: UserId,
+        value: &'static str,
+        is_regex: bool,
+        excluded_message_user_ids: Vec<UserId>,
+    }
+
+    struct FakeWordRepository {
+        words: Vec<FakeWord>,
+    }
+
+    impl WordRepository for FakeWordRepository {
+        async fn insert_word(&self, _word: NewWord) -> Result<()> {
+            panic!("insert_word should not be called")
+        }
+
+        async fn get_all_words(&self) -> Result<Vec<Word>> {
+            Ok(self
+                .words
+                .iter()
+                .enumerate()
+                .map(|(index, word)| Word {
+                    id: WordId(index as i64 + 1),
+                    uuid: WordUuid(Uuid::from_u128(index as u128 + 1)),
+                    user_id: word.target_user_id,
+                    value: WordValue(word.value.to_string()),
+                    is_regex: word.is_regex,
+                    excluded_message_user_ids: word.excluded_message_user_ids.clone(),
+                })
+                .collect())
+        }
+
+        async fn find_words_by_user_id(&self, _user_id: &UserId) -> Result<Vec<Word>> {
+            panic!("find_words_by_user_id should not be called")
+        }
+
+        async fn delete_word(&self, _word_id: &WordId) -> Result<()> {
+            panic!("delete_word should not be called")
+        }
+    }
+
+    struct FakeUserRepository {
+        target_user_id: UserId,
+        target_user_uuid: Uuid,
+    }
+
+    impl UserRepository for FakeUserRepository {
+        async fn upsert_users(&self, _users: Vec<NewUser>) -> Result<()> {
+            panic!("upsert_users should not be called")
+        }
+
+        async fn find_by_id(&self, user_id: &UserId) -> Result<User> {
+            if *user_id != self.target_user_id {
+                return Err(anyhow!("unexpected user id"));
+            }
+
+            Ok(User {
+                id: self.target_user_id,
+                display_name: "Target User".to_string(),
+                traq_id: "target".to_string(),
+                traq_uuid: self.target_user_uuid,
+                is_bot: false,
+                is_expired: false,
+            })
+        }
+
+        async fn find_by_traq_id(&self, _traq_id: &str) -> Result<User> {
+            panic!("find_by_traq_id should not be called")
+        }
+
+        async fn find_by_traq_uuid(&self, _traq_uuid: Uuid) -> Result<User> {
+            panic!("find_by_traq_uuid should not be called")
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct RecordedWordNotification {
+        target_user_uuid: Uuid,
+        matched_word_values: Vec<String>,
+        message_uuid: Uuid,
+    }
+
+    struct FakeNotificationService {
+        notifications: Mutex<Vec<RecordedWordNotification>>,
+    }
+
+    impl FakeNotificationService {
+        fn new() -> Self {
+            Self {
+                notifications: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl NotificationService for FakeNotificationService {
+        async fn send_word_notification(&self, notification: WordNotification) -> Result<()> {
+            self.notifications
+                .lock()
+                .expect("notifications lock should not be poisoned")
+                .push(RecordedWordNotification {
+                    target_user_uuid: notification.target_user_uuid,
+                    matched_word_values: notification
+                        .matched_word_values
+                        .into_iter()
+                        .map(|word| word.0)
+                        .collect(),
+                    message_uuid: notification.message_uuid.0,
+                });
+            Ok(())
+        }
+
+        async fn send_stamp_notification(&self, _notification: StampNotification) -> Result<()> {
+            panic!("send_stamp_notification should not be called")
+        }
+    }
+
+    fn run_async<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build")
+            .block_on(future)
+    }
+
+    fn message_from(author_user_id: UserId, content: &str, uuid: Uuid) -> TraqMessage {
+        TraqMessage::new(
+            TraqMessageUuid::new(uuid),
+            author_user_id,
+            content.to_string(),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn sends_notification_when_word_matches() {
+        run_async(async {
+            let target_user_id = UserId(1);
+            let target_user_uuid = Uuid::from_u128(100);
+            let message_uuid = Uuid::from_u128(200);
+            let notification_service = Arc::new(FakeNotificationService::new());
+            let processor = MessageProcessor::new(
+                Arc::new(FakeWordRepository {
+                    words: vec![FakeWord {
+                        target_user_id,
+                        value: "traP",
+                        is_regex: false,
+                        excluded_message_user_ids: Vec::new(),
+                    }],
+                }),
+                notification_service.clone(),
+                Arc::new(FakeUserRepository {
+                    target_user_id,
+                    target_user_uuid,
+                }),
+            );
+
+            processor
+                .process_message(&message_from(UserId(2), "hello traP", message_uuid))
+                .await
+                .expect("message processing should succeed");
+
+            let notifications = notification_service
+                .notifications
+                .lock()
+                .expect("notifications lock should not be poisoned");
+            assert_eq!(
+                *notifications,
+                vec![RecordedWordNotification {
+                    target_user_uuid,
+                    matched_word_values: vec!["traP".to_string()],
+                    message_uuid,
+                }]
+            );
+        });
+    }
+
+    #[test]
+    fn does_not_notify_when_message_author_is_excluded() {
+        run_async(async {
+            let target_user_id = UserId(1);
+            let excluded_user_id = UserId(2);
+            let target_user_uuid = Uuid::from_u128(100);
+            let notification_service = Arc::new(FakeNotificationService::new());
+            let processor = MessageProcessor::new(
+                Arc::new(FakeWordRepository {
+                    words: vec![FakeWord {
+                        target_user_id,
+                        value: "traP",
+                        is_regex: false,
+                        excluded_message_user_ids: vec![excluded_user_id],
+                    }],
+                }),
+                notification_service.clone(),
+                Arc::new(FakeUserRepository {
+                    target_user_id,
+                    target_user_uuid,
+                }),
+            );
+
+            processor
+                .process_message(&message_from(
+                    excluded_user_id,
+                    "hello traP",
+                    Uuid::from_u128(200),
+                ))
+                .await
+                .expect("message processing should succeed");
+
+            let notifications = notification_service
+                .notifications
+                .lock()
+                .expect("notifications lock should not be poisoned");
+            assert!(notifications.is_empty());
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add MessageProcessor unit tests with hand-written fakes
- cover normal word notification and excluded author suppression

## Tests
- cargo test --workspace --all-features